### PR TITLE
Fix type of monitor.filter.window: window is not an integer

### DIFF
--- a/cmd/goma/config_test.go
+++ b/cmd/goma/config_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+const content = `
+[[monitor]]
+[monitor.filter]
+window = 2
+`
+
+func writeToTempFile(content string) (string, error) {
+	tmpFile, err := ioutil.TempFile("", "")
+	if err != nil {
+		return "", err
+	}
+	defer tmpFile.Close()
+	_, err = tmpFile.WriteString(content)
+	if err != nil {
+		return "", err
+	}
+	return tmpFile.Name(), nil
+}
+
+func TestLoadTOML(t *testing.T) {
+	tmpFileName, err := writeToTempFile(content)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpFileName)
+
+	monitor, err := loadTOML(tmpFileName)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	v := monitor[0].Filter["window"]
+	_, ok := v.(int64)
+	if !ok {
+		t.Fatalf("monitor[0].filter.window is not int64: %T", v)
+	}
+}

--- a/filters/average/filter.go
+++ b/filters/average/filter.go
@@ -50,9 +50,9 @@ func construct(params map[string]interface{}) (filters.Filter, error) {
 		}
 	}
 
-	var window = defaultWindowSize
+	var window int64 = defaultWindowSize
 	if v, ok := params["window"]; ok {
-		window, ok = v.(int)
+		window, ok = v.(int64)
 		if !ok {
 			return nil, fmt.Errorf("window is not an integer: %v", v)
 		}

--- a/filters/average/filter_test.go
+++ b/filters/average/filter_test.go
@@ -32,7 +32,7 @@ func TestWindow(t *testing.T) {
 	}
 
 	f, err := construct(map[string]interface{}{
-		"window": 20,
+		"window": int64(20),
 	})
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
This PR fixes the following bug.

```shell
$ goma register example.toml
Server error: 400 Bad Request
example: window is not an integer: 2 in filter
```

The content of `example.toml` is as follows.

```toml
[[monitor]]
name = "example"

  [monitor.probe]
  type = "exec"
  command = "true"

  [monitor.filter]
  type = "average"
  window = 2

  [[monitor.actions]]
  type = "exec"
  command = "true"
```

The TOML specification says that 64 bit range is expected.

See https://github.com/toml-lang/toml#integer