### PR TITLE
fix HTTP cancellation test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-    - image: quay.io/cybozu/golang:1.11-bionic
+    - image: quay.io/cybozu/golang:1.15-focal
     working_directory: /work
     steps:
     - checkout

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Read [USAGE.md](USAGE.md) for details.
 Install
 -------
 
-Use Go 1.7 or better.
+The latest officially supported Go version is recommended.
 
 ```
 go get github.com/cybozu-go/goma/cmd/goma

--- a/actions/http/action_test.go
+++ b/actions/http/action_test.go
@@ -1,6 +1,8 @@
 package http
 
 import (
+	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"log"
@@ -272,11 +274,7 @@ func TestTimeout(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// When request is canceled, net/http returns an unexported error
-	// (errRequestCanceled = errors.New("net/http: request canceled").
-	//
-	// To test cancelation, only we can do here is to test err != nil.
-	if err := a.Init("monitor1"); err == nil {
-		t.Error(`err := a.Init("monitor1"); err == nil`)
+	if err := a.Init("monitor1"); !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("expected %v, got %v", context.DeadlineExceeded, err)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/cybozu-go/goma
 
+go 1.15
+
 require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/cybozu-go/log v1.5.0


### PR DESCRIPTION
Closes #6

This fixes the workaround used for the HTTP cancellation test as context.DeadlineExceeded is now available